### PR TITLE
poetry-dynamic-versioning 0.23.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "poetry-dynamic-versioning" %}
 {% set version = "0.23.0" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -12,20 +11,22 @@ source:
 
 build:
   number: 0
-  noarch: python
   entry_points:
     - poetry-dynamic-versioning = poetry_dynamic_versioning.__main__:main
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  skip: True  # [py<37]
 
 requirements:
   host:
     - pip
-    - poetry-core >=1.0.0
-    - python >=3.7
+    - poetry-core 1.5.1
+    - python
+    - setuptools
+    - wheel
   run:
     - dunamai >=1.17.0,<2.0.0
     - jinja2 >=2.11.1,<4
-    - python >=3.7
+    - python
     - tomlkit >=0.4
   run_constrained:
     - poetry >=1.2.0,<2
@@ -33,16 +34,20 @@ requirements:
 test:
   imports:
     - poetry_dynamic_versioning
+  requires:
+    - pip
   commands:
     - pip check
     - poetry-dynamic-versioning --help
-  requires:
-    - pip
 
 about:
   home: https://github.com/mtkennerly/poetry-dynamic-versioning
+  dev_url: https://github.com/mtkennerly/poetry-dynamic-versioning
+  doc_url: https://github.com/mtkennerly/poetry-dynamic-versioning
   summary: Plugin for Poetry to enable dynamic versioning based on VCS tags
+  description: Plugin for Poetry to enable dynamic versioning based on VCS tags
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   entry_points:
     - poetry-dynamic-versioning = poetry_dynamic_versioning.__main__:main
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<37]
 
 requirements:


### PR DESCRIPTION
Changelog: https://github.com/mtkennerly/poetry-dynamic-versioning/blob/v0.23.0/CHANGELOG.md
License: https://github.com/mtkennerly/poetry-dynamic-versioning/blob/v0.23.0/LICENSE
Requirements: https://github.com/mtkennerly/poetry-dynamic-versioning/blob/v0.23.0/pyproject.toml


Actions:
1. Apply an initial **percy** [patch](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/test_patch.json) and run locally a [script](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/updater_standalone.py) to: 
  - Remove `noarch python`
  - Skip `py<37`
  - Add flags `--no-deps --no-build-isolation` to `script`
  - Add missing `setuptools` and `wheel` to `host`
  - Fix `python` in `host` and `run`
2. Add `poetry-core` pin **1.5.1** (note that 1.4.0 hasn't py311 support on ppc64le)
3. Add `dev_url` and `doc_url`
4. Add `description`
5. Add `license_family`

Notes:
- `interface_meta` requires it https://github.com/AnacondaRecipes/interface_meta-feedstock/blob/2062db8c74626c782cbd7f2fc03d6864d37ba07a/recipe/meta.yaml#L22